### PR TITLE
Python3 Compatibility

### DIFF
--- a/Equation/__init__.py
+++ b/Equation/__init__.py
@@ -35,7 +35,10 @@ __desc__      = "General Equation Parser and Evaluator"
 
 all = ['util']
 
-from core import Expression
+try:
+    from Equation.core import Expression
+except ImportError:
+    from core import Expression
 
 def load():
     import os
@@ -43,7 +46,10 @@ def load():
     import sys
     import traceback
     import importlib
-    from core import recalculateFMatch
+    try:
+        from Equation.core import recalculateFMatch
+    except ImportError:
+        from core import recalculateFMatch
     if not hasattr(load, "loaded"):
         load.loaded = False
     if not load.loaded:
@@ -62,7 +68,7 @@ def load():
             plugin_file,extension = os.path.splitext(os.path.basename(file))
             if not plugin_file.lower().startswith("equation_",0,9) or extension.lower() not in ['.py','.pyc']:
                 continue
-            if not plugins_loaded.has_key(plugin_file):
+            if plugin_file not in plugins_loaded:
                 plugins_loaded[plugin_file] = 1
                 try:
                         plugin_script = importlib.import_module(prefix + plugin_file)

--- a/Equation/core.py
+++ b/Equation/core.py
@@ -12,11 +12,17 @@
 .. moduleauthor:: Glen Fletcher <glen.fletcher@alphaomega-technology.com.au>
 """
 
+from __future__ import print_function
+
 from . import __authors__,__copyright__,__license__,__contact__,__version__
 
 import numpy as np
 import sys
 import re
+
+if sys.version_info.major == 3:
+    xrange = range
+    basestring = str
 
 class ExpressionObject (object):
     def __init__(self,*args,**kwargs):
@@ -277,7 +283,7 @@ class Expression( object ):
         one token perline.
         """
         for expr in self.__expr:
-            print expr
+            print(expr)
             
     def __str__(self):
         """str(fn)
@@ -322,11 +328,17 @@ class Expression( object ):
         else:
             return args[0]
             
-    def __cmp__(self,other):
-        if isinstance(other,Expression):
-            return cmp(repr(self),repr(other))
+    def __lt__(self, other):
+        if isinstance(other, Expression):
+            return repr(self) < repr(other)
         else:
-            raise TypeError("{0:s} is not an {1:s} Object, and can't be compared to an Expression Object".format(repr(other),type(other)))
+            raise TypeError("{0:s} is not an {1:s} Object, and can't be compared to an Expression Object".format(repr(other), type(other)))
+
+    def __eq__(self, other):
+        if isinstance(other, Expression):
+            return repr(self) == repr(other)
+        else:
+            raise TypeError("{0:s} is not an {1:s} Object, and can't be compared to an Expression Object".format(repr(other), type(other)))
     
     def __combine(self,other,op):  
         if op not in ops or not isinstance(other,(int,float,complex,type(self),basestring)):

--- a/Equation/equation_base.py
+++ b/Equation/equation_base.py
@@ -26,7 +26,7 @@ def equation_extend():
     addOp('+',"({0:s} + {1:s})","\\left({0:s} + {1:s}\\right)",False,1,op.add)
     addOp('-',"({0:s} - {1:s})","\\left({0:s} - {1:s}\\right)",False,1,op.sub)
     addOp('*',"({0:s} * {1:s})","\\left({0:s} \\times {1:s}\\right)",False,2,op.mul)
-    addOp('/',"({0:s} / {1:s})","\\frac{{{0:s}}}{{{1:s}}}",False,2,op.div)
+    addOp('/',"({0:s} / {1:s})","\\frac{{{0:s}}}{{{1:s}}}",False,2,op.truediv)
     addOp('%',"({0:s} % {1:s})","\\left({0:s} \\bmod {1:s}\\right)",False,2,op.mod)
     addOp('^',"({0:s} ^ {1:s})","{0:s}^{{{1:s}}}",False,3,op.pow)
     addOp('&',"({0:s} & {1:s})","\\left({0:s} \\land {1:s}\\right)",False,1,op.and_)

--- a/Equation/util.py
+++ b/Equation/util.py
@@ -14,7 +14,10 @@ Created on Fri Apr 11 00:51:34 2014
 """
 
 from . import __authors__,__copyright__,__license__,__contact__,__version__
-import core
+try:
+    from Equation import core
+except ImportError:
+    import core
 
 def addFn(id,str,latex,args,func):
     core.functions[id] = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+scipy>=0.12.0

--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,13 @@ setup(
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
         "Topic :: Scientific/Engineering :: Mathematics",
-        ]
+        'Natural Language :: English',
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.6",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4",
+    ],
+    zip_safe=False,
 )


### PR DESCRIPTION
I am interested in using this module, but the setup.py was broken.
I also added python3 compatibility.

I will follow up with a test automation configuation for using the travis-ci.org github hook to avoid regressions on setup, python2 and python3.

>  Fix setup.py's bad closing brace 
> Fix Module imports
> Replace deprecated dict.has_key call
> Use print functions
> Alias xrange for range in python3 where they do the same thing
> Alias basestring for python3 which combines unicode and str into str
> Split __cmp__ into __lt__ and __eq__because __cmp\__ is deprecated in python3
> Replace operations.div by operations.truediv because the prior is deprecated in python3
> Add requirements file for pip install -r requirements.txt which is pretty standard for python projects.
> Add language classifier information
> Set zip_safe=False to avoid errors while installing
