### PR TITLE
Reduce minimum setuptools version

### DIFF
--- a/ez_setup.py
+++ b/ez_setup.py
@@ -31,7 +31,7 @@ try:
 except ImportError:
     USER_SITE = None
 
-DEFAULT_VERSION = "3.4.3"
+DEFAULT_VERSION = "2.1"
 DEFAULT_URL = "https://pypi.python.org/packages/source/s/setuptools/"
 
 def _python_cmd(*args):

--- a/tox.ini
+++ b/tox.ini
@@ -8,25 +8,21 @@ commands =
     python setup.py test
 deps =
     -r{toxinidir}/requirements.txt
-    setuptools==3.4.4
 
 [testenv:pep8]
 deps =
     flake8
-    setuptools==3.4.4
 commands = python setup.py flake8
 
 [testenv:pylint]
 deps =
     pylint
-    setuptools==3.4.4
 commands = pylint Equation -d R0903,E0611,W0403,E1101
 
 [testenv:coverage]
 deps =
     -r{toxinidir}/requirements.txt
     coverage
-    setuptools==3.4.4
 commands =
     coverage run setup.py test
     coverage report --include="Equation/*" -m --fail-under=50
@@ -36,5 +32,4 @@ commands =
 deps =
     -r{toxinidir}/requirements.txt
     sphinx
-    setuptools==3.4.4
 commands = sphinx-apidoc -o docs/ Equation


### PR DESCRIPTION
There is no need to have such a high version of setuptools as far as I can tell.
Having it higher than 2.1 makes it difficult to deploy on machines which have setuptools 2.1 or lower.
Travis is one of these.
