### PR TITLE
Format to PEP8 coding style, spelling fixes

### DIFF
--- a/Equation/__init__.py
+++ b/Equation/__init__.py
@@ -1,12 +1,13 @@
-#==============================================================================
+# -*- coding: utf-8 -*-
+###############################################################################
 #   Copyright 2014 AlphaOmega Technology
-# 
+#
 #   Licensed under the AlphaOmega Technology Open License Version 1.0
 #   You may not use this file except in compliance with this License.
 #   You may obtain a copy of the License at
-#  
+#
 #       http://www.alphaomega-technology.com.au/license/AOT-OL/1.0
-#==============================================================================
+###############################################################################
 """
 Equation Module
 ===============
@@ -15,30 +16,31 @@ This is the only module you should need to import
 
 It maps the Expression Class from `Equation.core.Expression`
 
-Its recomended you use the code::
+It's recommended you use the code::
 
     from Equation import Expression
     ...
-    
+
 to import the Expression Class, as this is the only Class/Function you
 should use.
 
 .. moduleauthor:: Glen Fletcher <glen.fletcher@alphaomega-technology.com.au>
 """
-__authors__   = [("Glen Fletcher","glen.fletcher@alphaomega-technology.com.au")]
+__authors__ = [("Glen Fletcher", "glen.fletcher@alphaomega-technology.com.au")]
 __copyright__ = "(c) 2014, AlphaOmega Technology"
-__license__   = "AlphaOmega Technology Open License Version 1.0 (http://www.alphaomega-technology.com.au/license/AOT-OL/1.0)"
-__contact__   = "Glen Fletcher <glen.fletcher@alphaomega-technology.com.au>"
-__version__   = "1.2"
-__title__     = "Equation"
-__desc__      = "General Equation Parser and Evaluator"
+__license__ = "AlphaOmega Technology Open License Version 1.0 (http://www.alphaomega-technology.com.au/license/AOT-OL/1.0)"
+__contact__ = "Glen Fletcher <glen.fletcher@alphaomega-technology.com.au>"
+__version__ = "1.2"
+__title__ = "Equation"
+__desc__ = "General Equation Parser and Evaluator"
 
 all = ['util']
 
 try:
-    from Equation.core import Expression
+    from Equation.core import Expression  # noqa
 except ImportError:
-    from core import Expression
+    from core import Expression  # noqa
+
 
 def load():
     import os
@@ -50,23 +52,23 @@ def load():
         from Equation.core import recalculateFMatch
     except ImportError:
         from core import recalculateFMatch
-    if not hasattr(load, "loaded"):
-        load.loaded = False
-    if not load.loaded:
-        load.loaded = True
+    if not hasattr(load, "loaded"):  # noqa
+        load.loaded = False  # noqa
+    if not load.loaded:  # noqa
+        load.loaded = True  # noqa
         plugins_loaded = {}
         if __name__ == "__main__":
             dirname = os.path.abspath(os.getcwd())
             prefix = ""
         else:
             dirname = os.path.dirname(os.path.abspath(__file__))
-            if __package__ != None:
+            if __package__ is not None:
                 prefix = __package__ + "."
             else:
                 prefix = ""
         for file in os.listdir(dirname):
-            plugin_file,extension = os.path.splitext(os.path.basename(file))
-            if not plugin_file.lower().startswith("equation_",0,9) or extension.lower() not in ['.py','.pyc']:
+            plugin_file, extension = os.path.splitext(os.path.basename(file))
+            if not plugin_file.lower().startswith("equation_", 0, 9) or extension.lower() not in ['.py', '.pyc']:
                 continue
             if plugin_file not in plugins_loaded:
                 plugins_loaded[plugin_file] = 1
@@ -77,8 +79,8 @@ def load():
                         fulltrace = ''.join(traceback.format_exception(errtype, errinfo, errtrace)[1:])
                         sys.stderr.write("Was unable to load {0:s}: {1:s}\nTraceback:\n{2:s}\n".format(plugin_file, errinfo, fulltrace))
                         continue
-                if not hasattr(plugin_script,'equation_extend'):
-                    sys.stderr.write("The plugin '{0:s}' from file '{1:s}' is invalid because its missing the attribute 'equation_extend'\n".format(plugin_file,(dirname.rstrip('/') + '/' + plugin_file + extension)))
+                if not hasattr(plugin_script, 'equation_extend'):
+                    sys.stderr.write("The plugin '{0:s}' from file '{1:s}' is invalid because its missing the attribute 'equation_extend'\n".format(plugin_file, (dirname.rstrip('/') + '/' + plugin_file + extension)))
                     continue
                 plugin_script.equation_extend()
         recalculateFMatch()

--- a/Equation/core.py
+++ b/Equation/core.py
@@ -1,17 +1,15 @@
 # -*- coding: utf-8 -*-
-#==============================================================================
+###############################################################################
 #   Copyright 2014 AlphaOmega Technology
-# 
+#
 #   Licensed under the AlphaOmega Technology Open License Version 1.0
 #   You may not use this file except in compliance with this License.
 #   You may obtain a copy of the License at
-#  
+#
 #       http://www.alphaomega-technology.com.au/license/AOT-OL/1.0
-#==============================================================================
+###############################################################################
 
 from __future__ import print_function
-
-from . import __authors__,__copyright__,__license__,__contact__,__version__
 
 import math
 
@@ -22,41 +20,43 @@ if sys.version_info >= (3,):
     xrange = range
     basestring = str
 
+
 class ExpressionObject (object):
-    def __init__(self,*args,**kwargs):
-        super(ExpressionObject,self).__init__(*args,**kwargs)
+    def __init__(self, *args, **kwargs):
+        super(ExpressionObject, self).__init__(*args, **kwargs)
 
-    def toStr(self,args,expression):
+    def toStr(self, args, expression):
         return ""
 
-    def toRepr(self,args,expression):
+    def toRepr(self, args, expression):
         return ""
 
-    def __call__(self,args,expression):
+    def __call__(self, args, expression):
         pass
-        
-class ExpressionValue( ExpressionObject ):
-    def __init__(self,value,*args,**kwargs):
-        super(ExpressionValue,self).__init__(*args,**kwargs)
+
+
+class ExpressionValue(ExpressionObject):
+    def __init__(self, value, *args, **kwargs):
+        super(ExpressionValue, self).__init__(*args, **kwargs)
         self.value = value
 
-    def toStr(self,args,expression):
-        if (isinstance(self.value,complex)):
-            V = [self.value.real,self.value.imag]
-            E = [0,0]
-            B = [0,0]
-            out = ["",""]
+    def toStr(self, args, expression):
+        if isinstance(self.value, complex):
+            V = [self.value.real, self.value.imag]
+            E = [0, 0]
+            B = [0, 0]
+            out = ["", ""]
             for i in xrange(2):
                 if V[i] == 0:
                     E[i] = 0
                     B[i] = 0
                 else:
                     E[i] = int(math.floor(math.log10(abs(V[i]))))
-                    B[i] = V[i]*10**-E[i]
-                    if E[i] in [0,1,2,3] and str(V[i])[-2:] == ".0":
+                    B[i] = V[i] * 10 ** -E[i]
+                    if E[i] in [0, 1, 2, 3] and str(V[i])[-2:] == ".0":
                         B[i] = int(V[i])
                         E[i] = 0
-                    if E[i] in [-1,-2] and len(str(V[i])) <= 7:
+                    if E[i] in [-1, -2] and len(str(V[i])) <= 7:
                         B[i] = V[i]
                         E[i] = 0
                 if i == 1:
@@ -68,25 +68,23 @@ class ExpressionValue( ExpressionObject ):
                 else:
                     out[i] += fmt.format('.5f').format(B[i]).rstrip("0.")
                 if i == 1:
-                    out[i] += "\\imath"
+                    out[i] += r"\imath"
                 if E[i] != 0:
-                    out[i] += "\\times10^{{{0:d}}}".format(E[i])
-            return "\\left(" + ''.join(out) + "\\right)"
-        elif (isinstance(self.value,float)):
+                    out[i] += r"\times10^{{{0:d}}}".format(E[i])
+            return r"\left(" + ''.join(out) + r"\right)"
+        elif isinstance(self.value, float):
             V = self.value
-            E = 0
-            B = 0
             out = ""
             if V == 0:
                 E = 0
                 B = 0
             else:
                 E = int(math.floor(math.log10(abs(V))))
-                B = V*10**-E
-                if E in [0,1,2,3] and str(V)[-2:] == ".0":
+                B = V * 10 ** -E
+                if E in [0, 1, 2, 3] and str(V)[-2:] == ".0":
                     B = int(V)
                     E = 0
-                if E in [-1,-2] and len(str(V)) <= 7:
+                if E in [-1, -2] and len(str(V)) <= 7:
                     B = V
                     E = 0
             if type(B) == int:
@@ -94,25 +92,28 @@ class ExpressionValue( ExpressionObject ):
             else:
                 out += "{0:-.5f}".format(B).rstrip("0.")
             if E != 0:
-                out += "\\times10^{{{0:d}}}".format(E)
-                return "\\left(" + out + "\\right)"
+                out += r"\times10^{{{0:d}}}".format(E)
+                return r"\left(" + out + r"\right)"
             else:
                 return out
         else:
             return str(self.value)
-    
-    def toRepr(self,args,expression):
+
+    def toRepr(self, args, expression):
         return str(self.value)
 
-    def __call__(self,args,expression):
+    def __call__(self, args, expression):
         return self.value
-    
-    def __repr__(self):
-            return "<{0:s}.{1:s}({2:s}) object at {3:0=#10x}>".format(type(self).__module__,type(self).__name__,str(self.value),id(self))
 
-class ExpressionFunction( ExpressionObject ):
-    def __init__(self,function,nargs,form,display,id,isfunc,*args,**kwargs):
-        super(ExpressionFunction,self).__init__(*args,**kwargs)
+    def __repr__(self):
+            return "<{0:s}.{1:s}({2:s}) object at {3:0=#10x}>".format(
+                type(self).__module__, type(self).__name__, str(self.value), id(self)
+            )
+
+
+class ExpressionFunction(ExpressionObject):
+    def __init__(self, function, nargs, form, display, id, isfunc, *args, **kwargs):
+        super(ExpressionFunction, self).__init__(*args, **kwargs)
         self.function = function
         self.nargs = nargs
         self.form = form
@@ -120,7 +121,7 @@ class ExpressionFunction( ExpressionObject ):
         self.id = id
         self.isfunc = isfunc
 
-    def toStr(self,args,expression):
+    def toStr(self, args, expression):
         params = []
         for i in xrange(self.nargs):
             params.append(args.pop())
@@ -128,8 +129,8 @@ class ExpressionFunction( ExpressionObject ):
             return str(self.display.format(','.join(params[::-1])))
         else:
             return str(self.display.format(*params[::-1]))
-            
-    def toRepr(self,args,expression):
+
+    def toRepr(self, args, expression):
         params = []
         for i in xrange(self.nargs):
             params.append(args.pop())
@@ -137,47 +138,54 @@ class ExpressionFunction( ExpressionObject ):
             return str(self.form.format(','.join(params[::-1])))
         else:
             return str(self.form.format(*params[::-1]))
-            
-    def __call__(self,args,expression):
+
+    def __call__(self, args, expression):
         params = []
         for i in xrange(self.nargs):
             params.append(args.pop())
         return self.function(*params[::-1])
-    
-    def __repr__(self):
-        return "<{0:s}.{1:s}({2:s},{3:d}) object at {4:0=#10x}>".format(type(self).__module__,type(self).__name__,str(self.id),self.nargs,id(self))
 
-class ExpressionVariable( ExpressionObject ):
-    def __init__(self,name,*args,**kwargs):
-        super(ExpressionVariable,self).__init__(*args,**kwargs)
+    def __repr__(self):
+        return "<{0:s}.{1:s}({2:s},{3:d}) object at {4:0=#10x}>".format(
+            type(self).__module__, type(self).__name__, str(self.id), self.nargs, id(self)
+        )
+
+
+class ExpressionVariable(ExpressionObject):
+    def __init__(self, name, *args, **kwargs):
+        super(ExpressionVariable, self).__init__(*args, **kwargs)
         self.name = name
 
-    def toStr(self,args,expression):
+    def toStr(self, args, expression):
         return str(self.name)
 
-    def toRepr(self,args,expression):
+    def toRepr(self, args, expression):
         return str(self.name)
 
-    def __call__(self,args,expression):
+    def __call__(self, args, expression):
+        """Default variables to return 0"""
         if self.name in expression.variables:
             return expression.variables[self.name]
         else:
-            return 0 # Default variables to return 0
-        
-    def __repr__(self):
-        return "<{0:s}.{1:s}({2:s}) object at {3:0=#10x}>".format(type(self).__module__,type(self).__name__,str(self.name),id(self))
+            return 0
 
-class Expression( object ):
+    def __repr__(self):
+        return "<{0:s}.{1:s}({2:s}) object at {3:0=#10x}>".format(
+            type(self).__module__, type(self).__name__, str(self.name), id(self)
+        )
+
+
+class Expression(object):
     """Expression or Equation Object
-    
-    This is a object that respresents an equation string in a manner
+
+    This is a object that represents an equation string in a manner
     that allows for it to be evaluated
-    
+
     Arithmetic Operators:
         Expression objects support combining with the standard arithmetic operators
         to create new Expression objects, they may also be combined with numerical
-        constant, and strings containg a valid Expression.
-        
+        constant, and strings containing a valid Expression.
+
             >>> from Equation import Expression
             >>> fn = Expression("x")
             >>> fn += 2
@@ -191,36 +199,36 @@ class Expression( object ):
             (((x + 2) ^ 3) - z)
             >>> fn(1,2)
             25
-    
+
     Parameters
     ----------
     expression: str
-        String resprenstation of an equation
+        String representation of an equation
     argorder: list of str
         List of variable names, indicating the position of variable
-        for mapping from positional arguments    
+        for mapping from positional arguments
     """
-    def __init__(self,expression,argorder=[],*args,**kwargs):
-        super(Expression,self).__init__(*args,**kwargs)
-        if isinstance(expression,type(self)): # clone the object
+    def __init__(self, expression, argorder=[], *args, **kwargs):
+        super(Expression, self).__init__(*args, **kwargs)
+        if isinstance(expression, type(self)):  # clone the object
             self.__args = list(expression.__args)
-            self.__vars = dict(expression.__vars) # intenral array of preset variables
+            self.__vars = dict(expression.__vars)  # internal array of preset variables
             self.__argsused = set(expression.__argsused)
             self.__expr = list(expression.__expr)
-            self.variables = {} # call variables
+            self.variables = {}  # call variables
         else:
             self.__expression = expression
-            self.__args = argorder;
-            self.__vars = {} # intenral array of preset variables
+            self.__args = argorder
+            self.__vars = {}  # internal array of preset variables
             self.__argsused = set()
-            self.__expr = [] # compiled equation tokens
-            self.variables = {} # call variables
+            self.__expr = []  # compiled equation tokens
+            self.variables = {}  # call variables
             self.__compile()
             del self.__expression
-    
+
     def __getitem__(self, name):
         """fn[var]
-        
+
         Fetch the preset variable `var`,from the Expression Object
         """
         if name in self.__argsused:
@@ -230,20 +238,20 @@ class Expression( object ):
                 return None
         else:
             raise KeyError(name)
-    
-    def __setitem__(self,name,value):
+
+    def __setitem__(self, name, value):
         """fn[var] = value
-        
+
         Set the preset variable `var` to the value `value`
         """
         if name in self.__argsused:
             self.__vars[name] = value
         else:
             raise KeyError(name)
-    
-    def __delitem__(self,name):
+
+    def __delitem__(self, name):
         """del fn[var]
-        
+
         Removes the preset variable `var` from the Expression Object
         """
         if name in self.__argsused:
@@ -251,140 +259,145 @@ class Expression( object ):
                 del self.__vars[name]
         else:
             raise KeyError(name)
-            
+
     def __contains__(self, name):
         """var in fn
-        
+
         Returns True if `fn` has a preset variable `var`
         """
         return name in self.__argsused
-        
-    def __call__(self,*args,**kwargs):
+
+    def __call__(self, *args, **kwargs):
         """fn(\*args,\*\*kwargs)
-        
+
         Arguments
         ---------
         \*args:
             Positional variables, order as defined by argorder, then position in equation
         \*\*kwargs:
             List of variables to be used by the equation for evaluation
-            
+
         Returns
         -------
         varies
-            Result of evaluating the Expression, type will depende appon the expression and the variables used to evaluate the expression.
+            Result of evaluating the Expression, type will depend upon the expression and the variables used to evaluate the expression.
         """
         self.variables = {}
-        self.variables.update(constants) # i.e. pi, e, i, etc.
+        self.variables.update(constants)  # i.e. pi, e, i, etc.
         self.variables.update(self.__vars)
         if len(args) > len(self.__args):
             raise TypeError("<{0:s}.{1:s}({2:s}) object at {3:0=#10x}>() takes at most {4:d} arguments ({5:d} given)".format(
-                    type(self).__module__,type(self).__name__,repr(self),id(self),len(self.__args),len(args)))
+                type(self).__module__, type(self).__name__, repr(self), id(self), len(self.__args), len(args))
+            )
         for i in xrange(len(args)):
             if i < len(self.__args):
                 if self.__args[i] in kwargs:
                     raise TypeError("<{0:s}.{1:s}({2:s}) object at {3:0=#10x}>() got multiple values for keyword argument '{4:s}'".format(
-                        type(self).__module__,type(self).__name__,repr(self),id(self),self.__args[i]))
+                        type(self).__module__, type(self).__name__, repr(self), id(self), self.__args[i])
+                    )
                 self.variables[self.__args[i]] = args[i]
         self.variables.update(kwargs)
         for arg in self.__argsused:
             if arg not in self.variables:
                 min_args = len(self.__argsused - (set(self.__vars.keys()) | set(constants.keys())))
                 raise TypeError("<{0:s}.{1:s}({2:s}) object at {3:0=#10x}>() takes at least {4:d} arguments ({5:d} given) '{6:s}' not defined".format(
-                    type(self).__module__,type(self).__name__,repr(self),id(self),min_args,len(args)+len(kwargs),arg))
+                    type(self).__module__, type(self).__name__, repr(self), id(self), min_args, len(args) + len(kwargs), arg)
+                )
         expr = self.__expr[::-1]
-        args = [];
+        args = []
         while len(expr) > 0:
             t = expr.pop()
-            r = t(args,self)
+            r = t(args, self)
             args.append(r)
         if len(args) > 1:
             return args
         else:
             return args[0]
-        
-    def __next(self,__expect_op):
+
+    def __next(self, __expect_op):
         if __expect_op:
-            m = gematch.match(self.__expression)    
-            if m != None:
+            m = gematch.match(self.__expression)
+            if m is not None:
                 self.__expression = self.__expression[m.end():]
                 g = m.groups()
-                return g[0],'CLOSE'
+                return g[0], 'CLOSE'
             m = smatch.match(self.__expression)
-            if m != None:
+            if m is not None:
                 self.__expression = self.__expression[m.end():]
-                return ",",'SEP'
-            m = omatch.match(self.__expression)    
-            if m != None:
+                return ",", 'SEP'
+            m = omatch.match(self.__expression)  # noqa
+            if m is not None:
                 self.__expression = self.__expression[m.end():]
                 g = m.groups()
-                return g[0],'OP'
+                return g[0], 'OP'
         else:
-            m = gsmatch.match(self.__expression)    
-            if m != None:
+            m = gsmatch.match(self.__expression)
+            if m is not None:
                 self.__expression = self.__expression[m.end():]
                 g = m.groups()
-                return g[0],'OPEN'
+                return g[0], 'OPEN'
             m = vmatch.match(self.__expression)
-            if m != None:
+            if m is not None:
                 self.__expression = self.__expression[m.end():]
                 g = m.groupdict(0)
                 if g['dec']:
                     if g["ivalue"]:
-                        return complex(int(g["rsign"]+"1")*float(g["rvalue"])*10**int(g["rexpoent"]),int(g["isign"]+"1")*float(g["ivalue"])*10**int(g["iexpoent"])),'VALUE'
-                    elif g["rexpoent"] or g["rvalue"].find('.')>=0:
-                        return int(g["rsign"]+"1")*float(g["rvalue"])*10**int(g["rexpoent"]),'VALUE'
+                        return complex(
+                            int(g["rsign"] + "1") * float(g["rvalue"]) * 10 ** int(g["rexpoent"]),
+                            int(g["isign"] + "1") * float(g["ivalue"]) * 10 ** int(g["iexpoent"])), 'VALUE'
+                    elif g["rexpoent"] or g["rvalue"].find('.') >= 0:
+                        return int(g["rsign"] + "1") * float(g["rvalue"]) * 10 ** int(g["rexpoent"]), 'VALUE'
                     else:
-                        return int(g["rsign"]+"1")*int(g["rvalue"]),'VALUE'
+                        return int(g["rsign"] + "1") * int(g["rvalue"]), 'VALUE'
                 elif g["hex"]:
-                    return int(g["hexsign"]+"1")*int(g["hexvalue"],16),'VALUE'
+                    return int(g["hexsign"] + "1") * int(g["hexvalue"], 16), 'VALUE'
                 elif g["oct"]:
-                    return int(g["octsign"]+"1")*int(g["octvalue"],8),'VALUE'
+                    return int(g["octsign"] + "1") * int(g["octvalue"], 8), 'VALUE'
                 elif g["bin"]:
-                    return int(g["binsign"]+"1")*int(g["binvalue"],2),'VALUE'
+                    return int(g["binsign"] + "1") * int(g["binvalue"], 2), 'VALUE'
                 else:
                     raise NotImplemented("'{0:s}' Values Not Implemented Yet".format(m.string))
             m = nmatch.match(self.__expression)
-            if m != None:
+            if m is not None:
                 self.__expression = self.__expression[m.end():]
                 g = m.groups()
-                return g[0],'NAME'
-            m = fmatch.match(self.__expression)
-            if m != None:
+                return g[0], 'NAME'
+            m = fmatch.match(self.__expression)  # noqa
+            if m is not None:
                 self.__expression = self.__expression[m.end():]
                 g = m.groups()
-                return g[0],'FUNC'
-            m = umatch.match(self.__expression)
-            if m != None:
+                return g[0], 'FUNC'
+            m = umatch.match(self.__expression)  # noqa
+            if m is not None:
                 self.__expression = self.__expression[m.end():]
                 g = m.groups()
-                return g[0],'UNARY'
+                return g[0], 'UNARY'
             return None
 
     def show(self):
         """Show RPN tokens
-        
+
         This will print out the internal token list (RPN) of the expression
-        one token perline.
+        one token per line.
         """
         for expr in self.__expr:
             print(expr)
-            
+
     def __str__(self):
         """str(fn)
-        
+
         Generates a Printable version of the Expression
-        
+
         Returns
         -------
         str
-            Latex String respresation of the Expression, suitable for rendering the equation
+            Latex String representation of the Expression, suitable for rendering the equation
         """
         expr = self.__expr[::-1]
-        args = [];
+        args = []
         while len(expr) > 0:
             t = expr.pop()
-            r = t.toStr(args,self)
+            r = t.toStr(args, self)
             args.append(r)
         if len(args) > 1:
             return args
@@ -393,29 +406,29 @@ class Expression( object ):
 
     def __repr__(self):
         """repr(fn)
-        
-        Generates a String that correctrly respresents the equation
-        
+
+        Generates a String that correctly represents the equation
+
         Returns
         -------
         str
-            Convert the Expression to a String that passed to the constructor, will constuct
+            Convert the Expression to a String that passed to the constructor, will construct
             an identical equation object (in terms of sequence of tokens, and token type/value)
         """
         expr = self.__expr[::-1]
-        args = [];
+        args = []
         while len(expr) > 0:
             t = expr.pop()
-            r = t.toRepr(args,self)
+            r = t.toRepr(args, self)
             args.append(r)
         if len(args) > 1:
             return args
         else:
             return args[0]
-    
+
     def __iter__(self):
         return iter(self.__argsused)
-            
+
     def __lt__(self, other):
         if isinstance(other, Expression):
             return repr(self) < repr(other)
@@ -427,16 +440,16 @@ class Expression( object ):
             return repr(self) == repr(other)
         else:
             raise TypeError("{0:s} is not an {1:s} Object, and can't be compared to an Expression Object".format(repr(other), type(other)))
-    
-    def __combine(self,other,op):  
-        if op not in ops or not isinstance(other,(int,float,complex,type(self),basestring)):
+
+    def __combine(self, other, op):
+        if op not in ops or not isinstance(other, (int, float, complex, type(self), basestring)):
             return NotImplemented
         else:
             obj = type(self)(self)
-            if isinstance(other,(int,float,complex)):
+            if isinstance(other, (int, float, complex)):
                 obj.__expr.append(ExpressionValue(other))
             else:
-                if isinstance(other,basestring):
+                if isinstance(other, basestring):
                     try:
                         other = type(self)(other)
                     except:
@@ -446,24 +459,24 @@ class Expression( object ):
                 for v in other.__args:
                     if v not in obj.__args:
                         obj.__args.append(v)
-                for k,v in other.__vars.items():
+                for k, v in other.__vars.items():
                     if k not in obj.__vars:
                         obj.__vars[k] = v
                     elif v != obj.__vars[k]:
-                        raise RuntimeError("Predifined Variable Conflict in '{0:s}' two differing values defined".format(k))
+                        raise RuntimeError("Predefined Variable Conflict in '{0:s}' two differing values defined".format(k))
             fn = ops[op]
-            obj.__expr.append(ExpressionFunction(fn['func'],fn['args'],fn['str'],fn['latex'],op,False))
+            obj.__expr.append(ExpressionFunction(fn['func'], fn['args'], fn['str'], fn['latex'], op, False))
         return obj
 
-    def __rcombine(self,other,op):
-        if op not in ops or not isinstance(other,(int,float,complex,type(self),basestring)):
+    def __rcombine(self, other, op):
+        if op not in ops or not isinstance(other, (int, float, complex, type(self), basestring)):
             return NotImplemented
         else:
             obj = type(self)(self)
-            if isinstance(other,(int,float,complex)):
-                obj.__expr.insert(0,ExpressionValue(other))
+            if isinstance(other, (int, float, complex)):
+                obj.__expr.insert(0, ExpressionValue(other))
             else:
-                if isinstance(other,basestring):
+                if isinstance(other, basestring):
                     try:
                         other = type(self)(other)
                     except:
@@ -475,24 +488,24 @@ class Expression( object ):
                     if v not in __args:
                         __args.append(v)
                 obj.__args = __args
-                for k,v in other.__vars.items():
+                for k, v in other.__vars.items():
                     if k not in obj.__vars:
                         obj.__vars[k] = v
                     elif v != obj.__vars[k]:
-                        raise RuntimeError("Predifined Variable Conflict in '{0:s}' two differing values defined".format(k))
+                        raise RuntimeError("Predefined Variable Conflict in '{0:s}' two differing values defined".format(k))
             fn = ops[op]
-            obj.__expr.append(ExpressionFunction(fn['func'],fn['args'],fn['str'],fn['latex'],op,False))
+            obj.__expr.append(ExpressionFunction(fn['func'], fn['args'], fn['str'], fn['latex'], op, False))
         return obj
-        
-    def __icombine(self,other,op):  
-        if op not in ops or not isinstance(other,(int,float,complex,type(self),basestring)):
+
+    def __icombine(self, other, op):
+        if op not in ops or not isinstance(other, (int, float, complex, type(self), basestring)):
             return NotImplemented
         else:
             obj = self
-            if isinstance(other,(int,float,complex)):
+            if isinstance(other, (int, float, complex)):
                 obj.__expr.append(ExpressionValue(other))
             else:
-                if isinstance(other,basestring):
+                if isinstance(other, basestring):
                     try:
                         other = type(self)(other)
                     except:
@@ -502,132 +515,132 @@ class Expression( object ):
                 for v in other.__args:
                     if v not in obj.__args:
                         obj.__args.append(v)
-                for k,v in other.__vars.items():
+                for k, v in other.__vars.items():
                     if k not in obj.__vars:
                         obj.__vars[k] = v
                     elif v != obj.__vars[k]:
-                        raise RuntimeError("Predifined Variable Conflict in '{0:s}' two differing values defined".format(k))
+                        raise RuntimeError("Predefined Variable Conflict in '{0:s}' two differing values defined".format(k))
             fn = ops[op]
-            obj.__expr.append(ExpressionFunction(fn['func'],fn['args'],fn['str'],fn['latex'],op,False))
+            obj.__expr.append(ExpressionFunction(fn['func'], fn['args'], fn['str'], fn['latex'], op, False))
         return obj
 
-    def __apply(self,op):
+    def __apply(self, op):
         fn = unary_ops[op]
         obj = type(self)(self)
-        obj.__expr.append(ExpressionFunction(fn['func'],1,fn['str'],fn['latex'],op,False))
-        return obj
-    
-    def __applycall(self,op):
-        fn = functions[op]
-        if 1 not in fn['args'] or '*' not in fn['args']:
-            raise RuntimeError("Can't Apply {0:s} function, dosen't accept only 1 argument".format(op))
-        obj = type(self)(self)
-        obj.__expr.append(ExpressionFunction(fn['func'],1,fn['str'],fn['latex'],op,False))
+        obj.__expr.append(ExpressionFunction(fn['func'], 1, fn['str'], fn['latex'], op, False))
         return obj
 
-    def __add__(self,other):
-        return self.__combine(other,'+')
-    
-    def __sub__(self,other):
-        return self.__combine(other,'-')
-    
-    def __mul__(self,other):
-        return self.__combine(other,'*')
-    
-    def __div__(self,other):
-        return self.__combine(other,'/')
-    
-    def __truediv__(self,other):
-        return self.__combine(other,'/')
-    
-    def __pow__(self,other):
-        return self.__combine(other,'^')  
-    
-    def __mod__(self,other):
-        return self.__combine(other,'%')
-    
-    def __and__(self,other):
-        return self.__combine(other,'&')
-        
-    def __or__(self,other):
-        return self.__combine(other,'|')
-    
-    def __xor__(self,other):
-        return self.__combine(other,'</>')
-    
-    def __radd__(self,other):
-        return self.__rcombine(other,'+')
-    
-    def __rsub__(self,other):
-        return self.__rcombine(other,'-')
-    
-    def __rmul__(self,other):
-        return self.__rcombine(other,'*')
-    
-    def __rdiv__(self,other):
-        return self.__rcombine(other,'/')
-    
-    def __rtruediv__(self,other):
-        return self.__rcombine(other,'/')
-    
-    def __rpow__(self,other):
-        return self.__rcombine(other,'^')  
-    
-    def __rmod__(self,other):
-        return self.__rcombine(other,'%')
-    
-    def __rand__(self,other):
-        return self.__rcombine(other,'&')
-        
-    def __ror__(self,other):
-        return self.__rcombine(other,'|')
-    
-    def __rxor__(self,other):
-        return self.__rcombine(other,'</>')
-        
-    def __iadd__(self,other):
-        return self.__icombine(other,'+')
-    
-    def __isub__(self,other):
-        return self.__icombine(other,'-')
-    
-    def __imul__(self,other):
-        return self.__icombine(other,'*')
-    
-    def __idiv__(self,other):
-        return self.__icombine(other,'/')
-    
-    def __itruediv__(self,other):
-        return self.__icombine(other,'/')
-    
-    def __ipow__(self,other):
-        return self.__icombine(other,'^')  
-    
-    def __imod__(self,other):
-        return self.__icombine(other,'%')
-    
-    def __iand__(self,other):
-        return self.__icombine(other,'&')
-        
-    def __ior__(self,other):
-        return self.__icombine(other,'|')
-    
-    def __ixor__(self,other):
-        return self.__icombine(other,'</>')
-    
+    def __applycall(self, op):
+        fn = functions[op]
+        if 1 not in fn['args'] or '*' not in fn['args']:
+            raise RuntimeError("Can't Apply {0:s} function, doesn't accept only 1 argument".format(op))
+        obj = type(self)(self)
+        obj.__expr.append(ExpressionFunction(fn['func'], 1, fn['str'], fn['latex'], op, False))
+        return obj
+
+    def __add__(self, other):
+        return self.__combine(other, '+')
+
+    def __sub__(self, other):
+        return self.__combine(other, '-')
+
+    def __mul__(self, other):
+        return self.__combine(other, '*')
+
+    def __div__(self, other):
+        return self.__combine(other, '/')
+
+    def __truediv__(self, other):
+        return self.__combine(other, '/')
+
+    def __pow__(self, other):
+        return self.__combine(other, '^')
+
+    def __mod__(self, other):
+        return self.__combine(other, '%')
+
+    def __and__(self, other):
+        return self.__combine(other, '&')
+
+    def __or__(self, other):
+        return self.__combine(other, '|')
+
+    def __xor__(self, other):
+        return self.__combine(other, '</>')
+
+    def __radd__(self, other):
+        return self.__rcombine(other, '+')
+
+    def __rsub__(self, other):
+        return self.__rcombine(other, '-')
+
+    def __rmul__(self, other):
+        return self.__rcombine(other, '*')
+
+    def __rdiv__(self, other):
+        return self.__rcombine(other, '/')
+
+    def __rtruediv__(self, other):
+        return self.__rcombine(other, '/')
+
+    def __rpow__(self, other):
+        return self.__rcombine(other, '^')
+
+    def __rmod__(self, other):
+        return self.__rcombine(other, '%')
+
+    def __rand__(self, other):
+        return self.__rcombine(other, '&')
+
+    def __ror__(self, other):
+        return self.__rcombine(other, '|')
+
+    def __rxor__(self, other):
+        return self.__rcombine(other, '</>')
+
+    def __iadd__(self, other):
+        return self.__icombine(other, '+')
+
+    def __isub__(self, other):
+        return self.__icombine(other, '-')
+
+    def __imul__(self, other):
+        return self.__icombine(other, '*')
+
+    def __idiv__(self, other):
+        return self.__icombine(other, '/')
+
+    def __itruediv__(self, other):
+        return self.__icombine(other, '/')
+
+    def __ipow__(self, other):
+        return self.__icombine(other, '^')
+
+    def __imod__(self, other):
+        return self.__icombine(other, '%')
+
+    def __iand__(self, other):
+        return self.__icombine(other, '&')
+
+    def __ior__(self, other):
+        return self.__icombine(other, '|')
+
+    def __ixor__(self, other):
+        return self.__icombine(other, '</>')
+
     def __neg__(self):
         return self.__apply('-')
-    
+
     def __invert__(self):
         return self.__apply('!')
-    
+
     def __abs__(self):
         return self.__applycall('abs')
-    
-    def __getfunction(self,op):
+
+    def __getfunction(self, op):
         if op[1] == 'FUNC':
             fn = functions[op[0]]
-            fn['type'] = 'FUNC'            
+            fn['type'] = 'FUNC'
         elif op[1] == 'UNARY':
             fn = unary_ops[op[0]]
             fn['type'] = 'UNARY'
@@ -635,7 +648,7 @@ class Expression( object ):
         elif op[1] == 'OP':
             fn = ops[op[0]]
             fn['type'] = 'OP'
-        return fn            
+        return fn
 
     def __compile(self):
         self.__expr = []
@@ -643,15 +656,15 @@ class Expression( object ):
         argc = []
         __expect_op = False
         v = self.__next(__expect_op)
-        while v != None:
+        while v is not None:
             if not __expect_op and v[1] == "OPEN":
                 stack.append(v)
-                __expect_op = False       
+                __expect_op = False
             elif __expect_op and v[1] == "CLOSE":
                 op = stack.pop()
                 while op[1] != "OPEN":
                     fs = self.__getfunction(op)
-                    self.__expr.append(ExpressionFunction(fs['func'],fs['args'],fs['str'],fs['latex'],op[0],False))
+                    self.__expr.append(ExpressionFunction(fs['func'], fs['args'], fs['str'], fs['latex'], op[0], False))
                     op = stack.pop()
                 if len(stack) > 0 and stack[-1][0] in functions:
                     op = stack.pop()
@@ -659,14 +672,14 @@ class Expression( object ):
                     args = argc.pop()
                     if fs['args'] != '+' and (args != fs['args'] and args not in fs['args']):
                         raise SyntaxError("Invalid number of arguments for {0:s} function".format(op[0]))
-                    self.__expr.append(ExpressionFunction(fs['func'],args,fs['str'],fs['latex'],op[0],True))
+                    self.__expr.append(ExpressionFunction(fs['func'], args, fs['str'], fs['latex'], op[0], True))
                 __expect_op = True
             elif __expect_op and v[0] == ",":
                 argc[-1] += 1
                 op = stack.pop()
                 while op[1] != "OPEN":
                     fs = self.__getfunction(op)
-                    self.__expr.append(ExpressionFunction(fs['func'],fs['args'],fs['str'],fs['latex'],op[0],False))
+                    self.__expr.append(ExpressionFunction(fs['func'], fs['args'], fs['str'], fs['latex'], op[0], False))
                     op = stack.pop()
                 stack.append(op)
                 __expect_op = False
@@ -686,8 +699,10 @@ class Expression( object ):
                     continue
                 fs = self.__getfunction(op)
                 while True:
-                    if (fn['prec'] >= fs['prec']):
-                        self.__expr.append(ExpressionFunction(fs['func'],fs['args'],fs['str'],fs['latex'],op[0],False))
+                    if fn['prec'] >= fs['prec']:
+                        self.__expr.append(
+                            ExpressionFunction(fs['func'], fs['args'], fs['str'], fs['latex'], op[0], False)
+                        )
                         if len(stack) == 0:
                             stack.append(v)
                             break
@@ -695,7 +710,7 @@ class Expression( object ):
                         if op[0] == "(":
                             stack.append(op)
                             stack.append(v)
-                            break                            
+                            break
                         fs = self.__getfunction(op)
                     else:
                         stack.append(op)
@@ -720,13 +735,13 @@ class Expression( object ):
                 self.__expr.append(ExpressionValue(v[0]))
                 __expect_op = True
             else:
-                raise SyntaxError("Invalid Token \"{0:s}\" in Expression, Expected {1:s}".format(v,"Op" if __expect_op else "Value"))
+                raise SyntaxError("Invalid Token \"{0:s}\" in Expression, Expected {1:s}".format(v, "Op" if __expect_op else "Value"))
             v = self.__next(__expect_op)
         if len(stack) > 0:
             op = stack.pop()
             while op != "(":
                 fs = self.__getfunction(op)
-                self.__expr.append(ExpressionFunction(fs['func'],fs['args'],fs['str'],fs['latex'],op[0],False))
+                self.__expr.append(ExpressionFunction(fs['func'], fs['args'], fs['str'], fs['latex'], op[0], False))
                 if len(stack) > 0:
                     op = stack.pop()
                 else:
@@ -737,7 +752,7 @@ unary_ops = {}
 ops = {}
 functions = {}
 smatch = re.compile("\s*,")
-vmatch = re.compile("\s*"
+vmatch = re.compile("\s*"  # noqa
                     "(?:"
                         "(?P<oct>"
                             "(?P<octsign>[+-]?)"
@@ -778,11 +793,12 @@ nmatch = re.compile("\s*([a-zA-Z_][a-zA-Z0-9_]*)")
 gsmatch = re.compile('\s*(\()')
 gematch = re.compile('\s*(\))')
 
+
 def recalculateFMatch():
     global fmatch, omatch, umatch
     fks = sorted(functions.keys(), key=len, reverse=True)
     oks = sorted(ops.keys(), key=len, reverse=True)
     uks = sorted(unary_ops.keys(), key=len, reverse=True)
-    fmatch = re.compile('\s*(' + '|'.join(map(re.escape,fks)) + ')')
-    omatch = re.compile('\s*(' + '|'.join(map(re.escape,oks)) + ')')
-    umatch = re.compile('\s*(' + '|'.join(map(re.escape,uks)) + ')')
+    fmatch = re.compile('\s*(' + '|'.join(map(re.escape, fks)) + ')')
+    omatch = re.compile('\s*(' + '|'.join(map(re.escape, oks)) + ')')
+    umatch = re.compile('\s*(' + '|'.join(map(re.escape, uks)) + ')')

--- a/Equation/equation_base.py
+++ b/Equation/equation_base.py
@@ -1,18 +1,18 @@
 # -*- coding: utf-8 -*-
-#==============================================================================
+###############################################################################
 #   Copyright 2014 AlphaOmega Technology
-# 
+#
 #   Licensed under the AlphaOmega Technology Open License Version 1.0
 #   You may not use this file except in compliance with this License.
 #   You may obtain a copy of the License at
-#  
+#
 #       http://www.alphaomega-technology.com.au/license/AOT-OL/1.0
-#==============================================================================
+###############################################################################
 
-__authors__   = "Glen Fletcher"
+__authors__ = "Glen Fletcher"
 __copyright__ = "(c) 2014, AlphaOmega Technology"
-__license__   = "AlphaOmega Technology Open License Version 1.0"
-__contact__   = "Glen Fletcher <glen.fletcher@alphaomega-technology.com.au>"
+__license__ = "AlphaOmega Technology Open License Version 1.0"
+__contact__ = "Glen Fletcher <glen.fletcher@alphaomega-technology.com.au>"
 
 try:
     import numpy as np
@@ -24,72 +24,73 @@ import operator as op
 from Equation.util import addOp, addFn, addConst, addUnaryOp
 from Equation.similar import sim, nsim, gsim, lsim
 
+
 def equation_extend():
     def product(*args):
         if len(args) == 1 and has_numpy:
             return np.prod(args[0])
         else:
-            return reduce(op.mul,args,1)
-    
+            return reduce(op.mul, args, 1)  # noqa
+
     def sumargs(*args):
         if len(args) == 1:
             return sum(args[0])
         else:
             return sum(args)
-            
-    addOp('+',"({0:s} + {1:s})","\\left({0:s} + {1:s}\\right)",False,3,op.add)
-    addOp('-',"({0:s} - {1:s})","\\left({0:s} - {1:s}\\right)",False,3,op.sub)
-    addOp('*',"({0:s} * {1:s})","\\left({0:s} \\times {1:s}\\right)",False,2,op.mul)
-    addOp('/',"({0:s} / {1:s})","\\frac{{{0:s}}}{{{1:s}}}",False,2,op.truediv)
-    addOp('%',"({0:s} % {1:s})","\\left({0:s} \\bmod {1:s}\\right)",False,2,op.mod)
-    addOp('^',"({0:s} ^ {1:s})","{0:s}^{{{1:s}}}",False,1,op.pow)
-    addOp('**',"({0:s} ^ {1:s})","{0:s}^{{{1:s}}}",False,1,op.pow)
-    addOp('&',"({0:s} & {1:s})","\\left({0:s} \\land {1:s}\\right)",False,4,op.and_)
-    addOp('|',"({0:s} | {1:s})","\\left({0:s} \\lor {1:s}\\right)",False,4,op.or_)
-    addOp('</>',"({0:s} </> {1:s})","\\left({0:s} \\oplus {1:s}\\right)",False,4,op.xor)
-    addOp('&|',"({0:s} </> {1:s})","\\left({0:s} \\oplus {1:s}\\right)",False,4,op.xor)
-    addOp('|&',"({0:s} </> {1:s})","\\left({0:s} \\oplus {1:s}\\right)",False,4,op.xor)
-    addOp('==',"({0:s} == {1:s})","\\left({0:s} = {1:s}\\right)",False,5,op.eq)
-    addOp('=',"({0:s} == {1:s})","\\left({0:s} = {1:s}\\right)",False,5,op.eq)
-    addOp('~',"({0:s} ~ {1:s})","\\left({0:s} \\approx {1:s}\\right)",False,5,sim)
-    addOp('!~',"({0:s} !~ {1:s})","\\left({0:s} \\not\\approx {1:s}\\right)",False,5,nsim)
-    addOp('!=',"({0:s} != {1:s})","\\left({0:s} \\neg {1:s}\\right)",False,5,op.ne)
-    addOp('<>',"({0:s} != {1:s})","\\left({0:s} \\neg {1:s}\\right)",False,5,op.ne)
-    addOp('><',"({0:s} != {1:s})","\\left({0:s} \\neg {1:s}\\right)",False,5,op.ne)
-    addOp('<',"({0:s} < {1:s})","\\left({0:s} < {1:s}\\right)",False,5,op.lt)
-    addOp('>',"({0:s} > {1:s})","\\left({0:s} > {1:s}\\right)",False,5,op.gt)
-    addOp('<=',"({0:s} <= {1:s})","\\left({0:s} \\leq {1:s}\\right)",False,5,op.le)
-    addOp('>=',"({0:s} >= {1:s})","\\left({0:s} \\geq {1:s}\\right)",False,5,op.ge)
-    addOp('=<',"({0:s} <= {1:s})","\\left({0:s} \\leq {1:s}\\right)",False,5,op.le)
-    addOp('=>',"({0:s} >= {1:s})","\\left({0:s} \\geq {1:s}\\right)",False,5,op.ge)
-    addOp('<~',"({0:s} <~ {1:s})","\\left({0:s} \lessapprox {1:s}\\right)",False,5,lsim)
-    addOp('>~',"({0:s} >~ {1:s})","\\left({0:s} \\gtrapprox {1:s}\\right)",False,5,gsim)
-    addOp('~<',"({0:s} <~ {1:s})","\\left({0:s} \lessapprox {1:s}\\right)",False,5,lsim)
-    addOp('~>',"({0:s} >~ {1:s})","\\left({0:s} \\gtrapprox {1:s}\\right)",False,5,gsim)
-    addUnaryOp('!',"(!{0:s})","\\neg{0:s}",op.not_)
-    addUnaryOp('-',"-{0:s}","-{0:s}",op.neg)
-    addFn('abs',"abs({0:s})","\\left|{0:s}\\right|",1,op.abs)
-    addFn('sum',"sum({0:s})","\\sum\\left({0:s}\\right)",'+',sumargs)
-    addFn('prod',"prod({0:s})","\\prod\\left({0:s}\\right)",'+',product)
+
+    addOp('+', "({0:s} + {1:s})", r"\left({0:s} + {1:s}\right)", False, 3, op.add)
+    addOp('-', "({0:s} - {1:s})", r"\left({0:s} - {1:s}\right)", False, 3, op.sub)
+    addOp('*', "({0:s} * {1:s})", r"\left({0:s} \times {1:s}\right)", False, 2, op.mul)
+    addOp('/', "({0:s} / {1:s})", r"\frac{{{0:s}}}{{{1:s}}}", False, 2, op.truediv)
+    addOp('%', "({0:s} % {1:s})", r"\left({0:s} \bmod {1:s}\right)", False, 2, op.mod)
+    addOp('^', "({0:s} ^ {1:s})", r"{0:s}^{{{1:s}}}", False, 1, op.pow)
+    addOp('**', "({0:s} ^ {1:s})", r"{0:s}^{{{1:s}}}", False, 1, op.pow)
+    addOp('&', "({0:s} & {1:s})", r"\left({0:s} \land {1:s}\right)", False, 4, op.and_)
+    addOp('|', "({0:s} | {1:s})", r"\left({0:s} \lor {1:s}\right)", False, 4, op.or_)
+    addOp('</>', "({0:s} </> {1:s})", r"\left({0:s} \oplus {1:s}\right)", False, 4, op.xor)
+    addOp('&|', "({0:s} </> {1:s})", r"\left({0:s} \oplus {1:s}\right)", False, 4, op.xor)
+    addOp('|&', "({0:s} </> {1:s})", r"\left({0:s} \oplus {1:s}\right)", False, 4, op.xor)
+    addOp('==', "({0:s} == {1:s})", r"\left({0:s} = {1:s}\right)", False, 5, op.eq)
+    addOp('=', "({0:s} == {1:s})", r"\left({0:s} = {1:s}\right)", False, 5, op.eq)
+    addOp('~', "({0:s} ~ {1:s})", r"\left({0:s} \approx {1:s}\right)", False, 5, sim)
+    addOp('!~', "({0:s} !~ {1:s})", r"\left({0:s} \not\approx {1:s}\right)", False, 5, nsim)
+    addOp('!=', "({0:s} != {1:s})", r"\left({0:s} \neg {1:s}\right)", False, 5, op.ne)
+    addOp('<>', "({0:s} != {1:s})", r"\left({0:s} \neg {1:s}\right)", False, 5, op.ne)
+    addOp('><', "({0:s} != {1:s})", r"\left({0:s} \neg {1:s}\right)", False, 5, op.ne)
+    addOp('<', "({0:s} < {1:s})", r"\left({0:s} < {1:s}\right)", False, 5, op.lt)
+    addOp('>', "({0:s} > {1:s})", r"\left({0:s} > {1:s}\right)", False, 5, op.gt)
+    addOp('<=', "({0:s} <= {1:s})", r"\left({0:s} \leq {1:s}\right)", False, 5, op.le)
+    addOp('>=', "({0:s} >= {1:s})", r"\left({0:s} \geq {1:s}\right)", False, 5, op.ge)
+    addOp('=<', "({0:s} <= {1:s})", r"\left({0:s} \leq {1:s}\right)", False, 5, op.le)
+    addOp('=>', "({0:s} >= {1:s})", r"\left({0:s} \geq {1:s}\right)", False, 5, op.ge)
+    addOp('<~', "({0:s} <~ {1:s})", r"\left({0:s} \lessapprox {1:s}\right)", False, 5, lsim)
+    addOp('>~', "({0:s} >~ {1:s})", r"\left({0:s} \gtrapprox {1:s}\right)", False, 5, gsim)
+    addOp('~<', "({0:s} <~ {1:s})", r"\left({0:s} \lessapprox {1:s}\right)", False, 5, lsim)
+    addOp('~>', "({0:s} >~ {1:s})", r"\left({0:s} \gtrapprox {1:s}\right)", False, 5, gsim)
+    addUnaryOp('!', "(!{0:s})", r"\neg{0:s}", op.not_)
+    addUnaryOp('-', "-{0:s}", r"-{0:s}", op.neg)
+    addFn('abs', "abs({0:s})", r"\left|{0:s}\right|", 1, op.abs)
+    addFn('sum', "sum({0:s})", r"\sum\left({0:s}\right)", '+', sumargs)
+    addFn('prod', "prod({0:s})", r"\prod\left({0:s}\right)", '+', product)
     if has_numpy:
-        addFn('sin',"sin({0:s})","\\sin\\left({0:s}\\right)",1,np.sin)
-        addFn('cos',"cos({0:s})","\\cos\\left({0:s}\\right)",1,np.cos)
-        addFn('tan',"tan({0:s})","\\tan\\left({0:s}\\right)",1,np.tan)
-        addFn('re',"re({0:s})","\\Re\\left({0:s}\\right)",1,np.real)
-        addFn('im',"re({0:s})","\\Im\\left({0:s}\\right)",1,np.imag)
-        addFn('sqrt',"sqrt({0:s})","\\sqrt{{{0:s}}}",1,np.sqrt)
-        addConst("pi",np.pi)
-        addConst("e",np.e)
-        addConst("Inf",np.Inf)
-        addConst("NaN",np.NaN)
+        addFn('sin', "sin({0:s})", r"\sin\left({0:s}\right)", 1, np.sin)
+        addFn('cos', "cos({0:s})", r"\cos\left({0:s}\right)", 1, np.cos)
+        addFn('tan', "tan({0:s})", r"\tan\left({0:s}\right)", 1, np.tan)
+        addFn('re', "re({0:s})", r"\Re\left({0:s}\right)", 1, np.real)
+        addFn('im', "re({0:s})", r"\Im\left({0:s}\right)", 1, np.imag)
+        addFn('sqrt', "sqrt({0:s})", r"\sqrt{{{0:s}}}", 1, np.sqrt)
+        addConst("pi", np.pi)
+        addConst("e", np.e)
+        addConst("Inf", np.Inf)
+        addConst("NaN", np.NaN)
     else:
-        addFn('sin',"sin({0:s})","\\sin\\left({0:s}\\right)",1,math.sin)
-        addFn('cos',"cos({0:s})","\\cos\\left({0:s}\\right)",1,math.cos)
-        addFn('tan',"tan({0:s})","\\tan\\left({0:s}\\right)",1,math.tan)
-        addFn('re',"re({0:s})","\\Re\\left({0:s}\\right)",1,complex.real)
-        addFn('im',"re({0:s})","\\Im\\left({0:s}\\right)",1,complex.imag)
-        addFn('sqrt',"sqrt({0:s})","\\sqrt{{{0:s}}}",1,math.sqrt)
-        addConst("pi",math.pi)
-        addConst("e",math.e)
-        addConst("Inf",float("Inf"))
-        addConst("NaN",float("NaN"))
+        addFn('sin', "sin({0:s})", r"\sin\left({0:s}\right)", 1, math.sin)
+        addFn('cos', "cos({0:s})", r"\cos\left({0:s}\right)", 1, math.cos)
+        addFn('tan', "tan({0:s})", r"\tan\left({0:s}\right)", 1, math.tan)
+        addFn('re', "re({0:s})", r"\Re\left({0:s}\right)", 1, complex.real)
+        addFn('im', "re({0:s})", r"\Im\left({0:s}\right)", 1, complex.imag)
+        addFn('sqrt', "sqrt({0:s})", r"\sqrt{{{0:s}}}", 1, math.sqrt)
+        addConst("pi", math.pi)
+        addConst("e", math.e)
+        addConst("Inf", float("Inf"))
+        addConst("NaN", float("NaN"))

--- a/Equation/equation_scipy.py
+++ b/Equation/equation_scipy.py
@@ -1,39 +1,39 @@
 # -*- coding: utf-8 -*-
-#==============================================================================
+###############################################################################
 #   Copyright 2014 AlphaOmega Technology
-# 
+#
 #   Licensed under the AlphaOmega Technology Open License Version 1.0
 #   You may not use this file except in compliance with this License.
 #   You may obtain a copy of the License at
-#  
+#
 #       http://www.alphaomega-technology.com.au/license/AOT-OL/1.0
-#==============================================================================
-__authors__   = "Glen Fletcher"
+###############################################################################
+__authors__ = "Glen Fletcher"
 __copyright__ = "(c) 2014, AlphaOmega Technology"
-__license__   = "AlphaOmega Technology Open License Version 1.0"
-__contact__   = "Glen Fletcher <glen.fletcher@alphaomega-technology.com.au>"
+__license__ = "AlphaOmega Technology Open License Version 1.0"
+__contact__ = "Glen Fletcher <glen.fletcher@alphaomega-technology.com.au>"
 
 try:
     import scipy.constants
     from Equation.util import addConst
 
     def equation_extend():
-        addConst("h",scipy.constants.h)
-        addConst("hbar",scipy.constants.hbar)
-        addConst("m_e",scipy.constants.m_e)
-        addConst("m_p",scipy.constants.m_p)
-        addConst("m_n",scipy.constants.m_n)
-        addConst("c",scipy.constants.c)
-        addConst("N_A",scipy.constants.N_A)
-        addConst("mu_0",scipy.constants.mu_0)
-        addConst("eps_0",scipy.constants.epsilon_0)
-        addConst("k",scipy.constants.k)
-        addConst("G",scipy.constants.G)
-        addConst("g",scipy.constants.g)
-        addConst("q",scipy.constants.e)
-        addConst("R",scipy.constants.R)
-        addConst("sigma",scipy.constants.e)
-        addConst("Rb",scipy.constants.Rydberg)
+        addConst("h", scipy.constants.h)
+        addConst("hbar", scipy.constants.hbar)
+        addConst("m_e", scipy.constants.m_e)
+        addConst("m_p", scipy.constants.m_p)
+        addConst("m_n", scipy.constants.m_n)
+        addConst("c", scipy.constants.c)
+        addConst("N_A", scipy.constants.N_A)
+        addConst("mu_0", scipy.constants.mu_0)
+        addConst("eps_0", scipy.constants.epsilon_0)
+        addConst("k", scipy.constants.k)
+        addConst("G", scipy.constants.G)
+        addConst("g", scipy.constants.g)
+        addConst("q", scipy.constants.e)
+        addConst("R", scipy.constants.R)
+        addConst("sigma", scipy.constants.e)
+        addConst("Rb", scipy.constants.Rydberg)
 except ImportError:
     def equation_extend():
         pass

--- a/Equation/similar.py
+++ b/Equation/similar.py
@@ -1,31 +1,31 @@
 # -*- coding: utf-8 -*-
-#==============================================================================
+###############################################################################
 #   Copyright 2014 AlphaOmega Technology
-# 
+#
 #   Licensed under the AlphaOmega Technology Open License Version 1.0
 #   You may not use this file except in compliance with this License.
 #   You may obtain a copy of the License at
-#  
+#
 #       http://www.alphaomega-technology.com.au/license/AOT-OL/1.0
-#==============================================================================
+###############################################################################
 r"""
 .. _similar-module:
 
 Equation.similar Module
 =======================
 
-Provides support for similar type comparsion, and allows the tolerance to be changed
+Provides support for similar type comparison, and allows the tolerance to be changed
 
-Comparsions work by detriming if the following is true
+Comparison work by determining if the following is true
 
 .. math::
-    
+
     1-\frac{\min(A,B)}{\max(A,B)}\leq tolerance
-    
+
 If it is true the :math:`A` and :math:`B` are considered to be equal
 
-This module only needs to be imported if you need to change the tolerance for similarlity
-tests, otherwise you just need to use the similarlity operators in your expression
+This module only needs to be imported if you need to change the tolerance for similarity
+tests, otherwise you just need to use the similarity operators in your expression
 
 .. code-block:: python
 
@@ -46,56 +46,61 @@ tests, otherwise you just need to use the similarlity operators in your expressi
     >>> fn(1,1.001)
     True
 
-By default the tolerance is :math:`10^{-5}` Hence 1.001 isn't condisered similar to 1, but by
-changing the tolerance to :math:`10^{-2}`, 1.001 is condisered similar to 1
+By default the tolerance is :math:`10^{-5}` Hence 1.001 isn't considered similar to 1, but by
+changing the tolerance to :math:`10^{-2}`, 1.001 is considered similar to 1
 """
 
 _tol = 1e-5
 
-def sim(a,b):
-    if (a==b):
-        return True
-    elif a == 0 or b == 0:
-        return False
-    if (a<b):
-        return (1-a/b)<=_tol
-    else:
-        return (1-b/a)<=_tol
 
-def nsim(a,b):
-    if (a==b):
+def sim(a, b):
+    if a == b:
+        return True
+    elif a == 0 or b == 0:
+        return False
+    if a < b:
+        return (1 - a / b) <= _tol
+    else:
+        return (1 - b / a) <= _tol
+
+
+def nsim(a, b):
+    if a == b:
         return False
     elif a == 0 or b == 0:
         return True
-    if (a<b):
-        return (1-a/b)>_tol
+    if a < b:
+        return (1 - a / b) > _tol
     else:
-        return (1-b/a)>_tol
-    
-def gsim(a,b):
+        return (1 - b / a) > _tol
+
+
+def gsim(a, b):
     if a >= b:
         return True
-    return (1-a/b)<=_tol
+    return (1 - a / b) <= _tol
 
-def lsim(a,b):
+
+def lsim(a, b):
     if a <= b:
         return True
-    return (1-b/a)<=_tol
-    
+    return (1 - b / a) <= _tol
+
+
 def set_tol(value=1e-5):
     r"""Set Error Tolerance
-    
-    Set the tolerance for detriming if two numbers are simliar, i.e
+
+    Set the tolerance for determining if two numbers are similar, i.e
     :math:`\left|\frac{a}{b}\right| = 1 \pm tolerance`
-    
+
     Parameters
     ----------
     value: float
-        The Value to set the tolerance to show be very small as it respresents the
-        percentage of acceptable error in detriming if two values are the same.
+        The Value to set the tolerance to show be very small as it represents the
+        percentage of acceptable error in determining if two values are the same.
     """
     global _tol
-    if isinstance(value,float):
+    if isinstance(value, float):
         _tol = value
     else:
         raise TypeError(type(value))

--- a/Equation/util.py
+++ b/Equation/util.py
@@ -1,28 +1,29 @@
 # -*- coding: utf-8 -*-
-#==============================================================================
+###############################################################################
 #   Copyright 2014 AlphaOmega Technology
-# 
+#
 #   Licensed under the AlphaOmega Technology Open License Version 1.0
 #   You may not use this file except in compliance with this License.
 #   You may obtain a copy of the License at
-#  
+#
 #       http://www.alphaomega-technology.com.au/license/AOT-OL/1.0
-#==============================================================================
+###############################################################################
 
-from . import __authors__,__copyright__,__license__,__contact__,__version__
 try:
     from Equation import core
 except ImportError:
     import core
 
-def addFn(id,str,latex,args,func):
+
+def addFn(id, str, latex, args, func):
     core.functions[id] = {
         'str': str,
         'latex': latex,
         'args': args,
         'func': func}
 
-def addOp(id,str,latex,single,prec,func):
+
+def addOp(id, str, latex, single, prec, func):
     if single:
         raise RuntimeError("Single Ops Not Yet Supported")
     core.ops[id] = {
@@ -32,7 +33,8 @@ def addOp(id,str,latex,single,prec,func):
         'prec': prec,
         'func': func}
 
-def addUnaryOp(id,str,latex,func):
+
+def addUnaryOp(id, str, latex, func):
     core.unary_ops[id] = {
         'str': str,
         'latex': latex,
@@ -40,5 +42,6 @@ def addUnaryOp(id,str,latex,func):
         'prec': 0,
         'func': func}
 
-def addConst(name,value):
+
+def addConst(name, value):
     core.constants[name] = value

--- a/Note to developers.txt
+++ b/Note to developers.txt
@@ -1,5 +1,5 @@
 Please when adding new features to this project,
-create each seperate feature in its own branch.
+create each separate feature in its own branch.
 
 If one feature requires another to work please branch off
 that feature.
@@ -7,7 +7,7 @@ that feature.
 It is requires several please branch off the closes and merge
 the others.
 
-This allows indivdual features to be seperatly merged back into
+This allows individual features to be separately merged back into
 the master branch, once their working, and I have approved of them.
 
 Thanks

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,6 @@ all_files  = 1
 
 [upload_docs]
 upload-dir = doc/build/html
+
+[flake8]
+max-line-length = 119

--- a/tests/test_Equation.py
+++ b/tests/test_Equation.py
@@ -8,13 +8,14 @@ from Equation import Expression
 if sys.version_info.major == 3:
     xrange = range
 
+
 class TestEquation(unittest.TestCase):
     """Test example in README.md"""
     def setUp(self):
-        self.fn = Expression("sin(x+y^2)", ["y","x"])
-        
+        self.fn = Expression("sin(x+y^2)", ["y", "x"])
+
     def testRepr(self):
-        self.assertEqual(Expression(repr(self.fn)),self.fn)
+        self.assertEqual(Expression(repr(self.fn)), self.fn)
 
     def testCall(self):
         self.assertAlmostEqual(
@@ -33,9 +34,9 @@ class TestEquation(unittest.TestCase):
 class TestEquation2(unittest.TestCase):
     def setUp(self):
         self.fn = Expression("sin(x+y^2)")
-    
+
     def testRepr(self):
-        self.assertEqual(Expression(repr(self.fn)),self.fn)
+        self.assertEqual(Expression(repr(self.fn)), self.fn)
 
     def testCall(self):
         self.assertAlmostEqual(
@@ -54,9 +55,9 @@ class TestEquation2(unittest.TestCase):
 class TestEquation3(unittest.TestCase):
     def setUp(self):
         self.fn = Expression("x+y^2")
-        
+
     def testRepr(self):
-        self.assertEqual(Expression(repr(self.fn)),self.fn)
+        self.assertEqual(Expression(repr(self.fn)), self.fn)
 
     def testCall(self):
         self.assertEqual(self.fn(3, 4), 19)
@@ -65,44 +66,47 @@ class TestEquation3(unittest.TestCase):
     def tearDown(self):
         pass
 
+
 class TestComplexEquation(unittest.TestCase):
     def setUp(self):
         pass
 
     def testCall(self):
-        for expr,value in [ ("-8-2j",(-8-2j)),
-                            ("-(8+2j)",(-8-2j)),
-                            ("- 8+2j",(-8+2j)),
-                            ("-8-2i",(-8-2j)),
-                            ("-(8+2i)",(-8-2j)),
-                            ("- 8+2i",(-8+2j)),
-                            ("- 8 + -2j",(-8-2j)),
-                            ("-(8 + - 2j)",(-8+2j)),
-                            ("- 8 + +2j",(-8+2j)),
+        for expr, value in [("-8-2j", (-8 - 2j)),
+                            ("-(8+2j)", (-8 - 2j)),
+                            ("- 8+2j", (-8 + 2j)),
+                            ("-8-2i", (-8 - 2j)),
+                            ("-(8+2i)", (-8 - 2j)),
+                            ("- 8+2i", (-8 + 2j)),
+                            ("- 8 + -2j", (-8 - 2j)),
+                            ("-(8 + - 2j)", (-8 + 2j)),
+                            ("- 8 + +2j", (-8 + 2j)),
                             ]:
             result = Expression(expr)()
-            self.assertEqual(result,value,"Expression(\"{0:s}\")() = {1!r:s} not {2!r:s}".format(expr,result,value))
+            self.assertEqual(result, value, "Expression(\"{0:s}\")() = {1!r:s} not {2!r:s}".format(expr, result, value))
 
     def tearDown(self):
         pass
+
 
 class TestHexEquation(unittest.TestCase):
     def setUp(self):
         pass
 
     def testCall(self):
-        for n in xrange(-784323,294924,6831):
+        for n in xrange(-784323, 294924, 6831):
             if n < 0:
                 hexstr = hex(n)[3:]
                 prefix = "-0x"
             else:
                 hexstr = hex(n)[2:]
                 prefix = "0x"
-            self.assertEqual(Expression(prefix + hexstr)(),n)
-            self.assertEqual(Expression(prefix + hexstr.upper())(),n)
-    
+            self.assertEqual(Expression(prefix + hexstr)(), n)
+            self.assertEqual(Expression(prefix + hexstr.upper())(), n)
+
     def tearDown(self):
         pass
+
 
 class TestOctEquation(unittest.TestCase):
     def setUp(self):
@@ -113,41 +117,43 @@ class TestOctEquation(unittest.TestCase):
             l = 2
         else:
             l = 1
-        for n in xrange(-784323,294924,6831):
+        for n in xrange(-784323, 294924, 6831):
             if n < 0:
-                octstr = oct(n)[l+1:]
+                octstr = oct(n)[l + 1:]
                 prefix = "-0o"
             else:
                 octstr = oct(n)[l:]
                 prefix = "0o"
-            self.assertEqual(Expression(prefix + octstr)(),n)
-    
+            self.assertEqual(Expression(prefix + octstr)(), n)
+
     def tearDown(self):
         pass
+
 
 class TestBinEquation(unittest.TestCase):
     def setUp(self):
         pass
 
     def testCall(self):
-        for n in xrange(-784323,294924,6831):
+        for n in xrange(-784323, 294924, 6831):
             if n < 0:
                 binstr = bin(n)[3:]
                 prefix = "-0b"
             else:
                 binstr = bin(n)[2:]
                 prefix = "0b"
-            self.assertEqual(Expression(prefix + binstr)(),n)
-    
+            self.assertEqual(Expression(prefix + binstr)(), n)
+
     def tearDown(self):
         pass
+
 
 class TestAddEquation(unittest.TestCase):
     def setUp(self):
         self.fn = Expression("x + y")
-        
+
     def testRepr(self):
-        self.assertEqual(Expression(repr(self.fn)),self.fn)
+        self.assertEqual(Expression(repr(self.fn)), self.fn)
 
     def testCall(self):
         self.assertEqual(self.fn(1, 0), 1)
@@ -164,12 +170,13 @@ class TestAddEquation(unittest.TestCase):
     def tearDown(self):
         pass
 
+
 class TestSubtractEquation(unittest.TestCase):
     def setUp(self):
         self.fn = Expression("x - y")
-        
+
     def testRepr(self):
-        self.assertEqual(Expression(repr(self.fn)),self.fn)
+        self.assertEqual(Expression(repr(self.fn)), self.fn)
 
     def testCall(self):
         self.assertEqual(self.fn(1, 0), 1)
@@ -186,12 +193,13 @@ class TestSubtractEquation(unittest.TestCase):
     def tearDown(self):
         pass
 
+
 class TestMultiplyEquation(unittest.TestCase):
     def setUp(self):
         self.fn = Expression("x * y")
-        
+
     def testRepr(self):
-        self.assertEqual(Expression(repr(self.fn)),self.fn)
+        self.assertEqual(Expression(repr(self.fn)), self.fn)
 
     def testCall(self):
         self.assertEqual(self.fn(1, 0), 0)
@@ -207,13 +215,14 @@ class TestMultiplyEquation(unittest.TestCase):
 
     def tearDown(self):
         pass
-    
+
+
 class TestPowerEquation(unittest.TestCase):
     def setUp(self):
         self.fn = Expression("x ^ y")
-        
+
     def testRepr(self):
-        self.assertEqual(Expression(repr(self.fn)),self.fn)
+        self.assertEqual(Expression(repr(self.fn)), self.fn)
 
     def testCall(self):
         self.assertEqual(self.fn(1, 0), 1)
@@ -231,12 +240,13 @@ class TestPowerEquation(unittest.TestCase):
     def tearDown(self):
         pass
 
+
 class TestDivisionEquation(unittest.TestCase):
     def setUp(self):
         self.fn = Expression("x / y")
-        
+
     def testRepr(self):
-        self.assertEqual(Expression(repr(self.fn)),self.fn)
+        self.assertEqual(Expression(repr(self.fn)), self.fn)
 
     def testCall(self):
         self.assertEqual(self.fn(0, 1), 0)
@@ -245,7 +255,7 @@ class TestDivisionEquation(unittest.TestCase):
         self.assertEqual(self.fn(3, 1), 3)
         self.assertEqual(self.fn(15, 3), 5)
         with self.assertRaises(ZeroDivisionError):
-            self.fn(1,0)
+            self.fn(1, 0)
 
     def testType(self):
         self.assertEqual(type(self.fn(1, 2)), float)
@@ -255,12 +265,13 @@ class TestDivisionEquation(unittest.TestCase):
     def tearDown(self):
         pass
 
+
 class TestAndEquation(unittest.TestCase):
     def setUp(self):
         self.fn = Expression("x & y")
-        
+
     def testRepr(self):
-        self.assertEqual(Expression(repr(self.fn)),self.fn)
+        self.assertEqual(Expression(repr(self.fn)), self.fn)
 
     def testCall(self):
         self.assertEqual(self.fn(1, 0), 0)
@@ -280,9 +291,9 @@ class TestAndEquation(unittest.TestCase):
 class TestOrEquation(unittest.TestCase):
     def setUp(self):
         self.fn = Expression("x | y")
-        
+
     def testRepr(self):
-        self.assertEqual(Expression(repr(self.fn)),self.fn)
+        self.assertEqual(Expression(repr(self.fn)), self.fn)
 
     def testCall(self):
         self.assertEqual(self.fn(1, 0), 1)
@@ -299,13 +310,12 @@ class TestOrEquation(unittest.TestCase):
         pass
 
 
-
 class TestNotEquation(unittest.TestCase):
     def setUp(self):
         self.fn = Expression("!x")
-        
+
     def testRepr(self):
-        self.assertEqual(Expression(repr(self.fn)),self.fn)
+        self.assertEqual(Expression(repr(self.fn)), self.fn)
 
     def testCall(self):
         self.assertFalse(self.fn(1))
@@ -323,26 +333,28 @@ class TestNotEquation(unittest.TestCase):
     def tearDown(self):
         pass
 
+
 class TestNegEquation(unittest.TestCase):
     def setUp(self):
         self.fn = Expression("-x")
-        
+
     def testRepr(self):
-        self.assertEqual(Expression(repr(self.fn)),self.fn)
+        self.assertEqual(Expression(repr(self.fn)), self.fn)
 
     def testCall(self):
-        self.assertEqual(self.fn(1),-1)
-        self.assertEqual(self.fn(6+3j),(-6-3j))
+        self.assertEqual(self.fn(1), -1)
+        self.assertEqual(self.fn(6 + 3j), (-6 - 3j))
 
     def tearDown(self):
         pass
+
 
 class TestEqualsEquation(unittest.TestCase):
     def setUp(self):
         self.fn = Expression("x == y")
 
     def testRepr(self):
-        self.assertEqual(Expression(repr(self.fn)),self.fn)
+        self.assertEqual(Expression(repr(self.fn)), self.fn)
 
     def testCall(self):
         self.assertFalse(self.fn(1, 0))
@@ -362,29 +374,29 @@ class TestEqualsEquation(unittest.TestCase):
 
     def tearDown(self):
         pass
-    
+
 
 class TestSimilarEquation(unittest.TestCase):
     def setUp(self):
         self.fn = Expression("x ~ y")
 
     def testRepr(self):
-        self.assertEqual(Expression(repr(self.fn)),self.fn)
+        self.assertEqual(Expression(repr(self.fn)), self.fn)
 
     def testCall(self):
         # Only use values close to 1
-        # floating point error may caluse failure for large expoents
+        # floating point error may cause failure for large exponents
         # i.e. for 10000 (1-(a(1-1e-5))/a)=1.0000000000065512e-05
-        # This is floating due to folating point error
-        for a in [0.001,1,1.5,4,100,1000]: 
-            ge = a*(1+1e-5)
-            le = a*(1-1e-5)
-            gt = a*(1+1.1e-5)
-            lt = a*(1-1.1e-5)
-            self.assertTrue(self.fn(a,ge),"{0:g} ~ {1:g}, is False".format(a,ge))
-            self.assertTrue(self.fn(a,le),"{0:g} ~ {1:g}, is False".format(a,le))
-            self.assertFalse(self.fn(a,gt),"{0:g} ~ {1:g}, is True".format(a,gt))
-            self.assertFalse(self.fn(a,lt),"{0:g} ~ {1:g}, is True".format(a,lt))
+        # This is floating due to floating point error
+        for a in [0.001, 1, 1.5, 4, 100, 1000]:
+            ge = a * (1 + 1e-5)
+            le = a * (1 - 1e-5)
+            gt = a * (1 + 1.1e-5)
+            lt = a * (1 - 1.1e-5)
+            self.assertTrue(self.fn(a, ge), "{0:g} ~ {1:g}, is False".format(a, ge))
+            self.assertTrue(self.fn(a, le), "{0:g} ~ {1:g}, is False".format(a, le))
+            self.assertFalse(self.fn(a, gt), "{0:g} ~ {1:g}, is True".format(a, gt))
+            self.assertFalse(self.fn(a, lt), "{0:g} ~ {1:g}, is True".format(a, lt))
 
     def testType(self):
         self.assertEqual(type(self.fn(1, 1)), bool)
@@ -393,12 +405,13 @@ class TestSimilarEquation(unittest.TestCase):
     def tearDown(self):
         pass
 
+
 class TestNotEqualsEquation(unittest.TestCase):
     def setUp(self):
         self.fn = Expression("x != y")
-        
+
     def testRepr(self):
-        self.assertEqual(Expression(repr(self.fn)),self.fn)
+        self.assertEqual(Expression(repr(self.fn)), self.fn)
 
     def testCall(self):
         self.assertTrue(self.fn(1, 0))
@@ -419,27 +432,28 @@ class TestNotEqualsEquation(unittest.TestCase):
     def tearDown(self):
         pass
 
+
 class TestNotSimilarEquation(unittest.TestCase):
     def setUp(self):
         self.fn = Expression("x !~ y")
 
     def testRepr(self):
-        self.assertEqual(Expression(repr(self.fn)),self.fn)
+        self.assertEqual(Expression(repr(self.fn)), self.fn)
 
     def testCall(self):
         # Only use values close to 1
-        # floating point error may caluse failure for large expoents
+        # floating point error may cause failure for large exponents
         # i.e. for 10000 (1-(a(1-1e-5))/a)=1.0000000000065512e-05
-        # This is floating due to folating point error
-        for a in [0.001,1,1.5,4,100,1000]: 
-            ge = a*(1+1e-5)
-            le = a*(1-1e-5)
-            gt = a*(1+1.1e-5)
-            lt = a*(1-1.1e-5)
-            self.assertFalse(self.fn(a,ge),"{0:g} !~ {1:g}, is True".format(a,ge))
-            self.assertFalse(self.fn(a,le),"{0:g} !~ {1:g}, is True".format(a,le))
-            self.assertTrue(self.fn(a,gt),"{0:g} !~ {1:g}, is False".format(a,gt))
-            self.assertTrue(self.fn(a,lt),"{0:g} !~ {1:g}, is False".format(a,lt))
+        # This is floating due to floating point error
+        for a in [0.001, 1, 1.5, 4, 100, 1000]:
+            ge = a * (1 + 1e-5)
+            le = a * (1 - 1e-5)
+            gt = a * (1 + 1.1e-5)
+            lt = a * (1 - 1.1e-5)
+            self.assertFalse(self.fn(a, ge), "{0:g} !~ {1:g}, is True".format(a, ge))
+            self.assertFalse(self.fn(a, le), "{0:g} !~ {1:g}, is True".format(a, le))
+            self.assertTrue(self.fn(a, gt), "{0:g} !~ {1:g}, is False".format(a, gt))
+            self.assertTrue(self.fn(a, lt), "{0:g} !~ {1:g}, is False".format(a, lt))
 
     def testType(self):
         self.assertEqual(type(self.fn(1, 1)), bool)
@@ -452,10 +466,10 @@ class TestNotSimilarEquation(unittest.TestCase):
 class TestGreaterThanEquation(unittest.TestCase):
     def setUp(self):
         self.fn = Expression("x > y")
-        
+
     def testRepr(self):
-        self.assertEqual(Expression(repr(self.fn)),self.fn)        
-        
+        self.assertEqual(Expression(repr(self.fn)), self.fn)
+
     def testCall(self):
         self.assertTrue(self.fn(1, 0))
         self.assertFalse(self.fn(0, 0))
@@ -475,12 +489,13 @@ class TestGreaterThanEquation(unittest.TestCase):
     def tearDown(self):
         pass
 
+
 class TestGreaterThanOrEqualToEquation(unittest.TestCase):
     def setUp(self):
         self.fn = Expression("x >= y")
-        
+
     def testRepr(self):
-        self.assertEqual(Expression(repr(self.fn)),self.fn)
+        self.assertEqual(Expression(repr(self.fn)), self.fn)
 
     def testCall(self):
         self.assertTrue(self.fn(1, 0))
@@ -504,22 +519,22 @@ class TestGreaterThanOrSimilarToEquation(unittest.TestCase):
         self.fn = Expression("x >~ y")
 
     def testRepr(self):
-        self.assertEqual(Expression(repr(self.fn)),self.fn)
+        self.assertEqual(Expression(repr(self.fn)), self.fn)
 
     def testCall(self):
         # Only use values close to 1
-        # floating point error may caluse failure for large expoents
+        # floating point error may cause failure for large exponents
         # i.e. for 10000 (1-(a(1-1e-5))/a)=1.0000000000065512e-05
-        # This is floating due to folating point error
-        for a in [0.001,1,1.5,4,100,1000]: 
-            ge = a*(1+1e-5)
-            le = a*(1-1e-5)
-            gt = a*(1+1.1e-5)
-            lt = a*(1-1.1e-5)
-            self.assertTrue(self.fn(a,ge),"{0:g} >~ {1:g}, is False".format(a,ge))
-            self.assertTrue(self.fn(a,le),"{0:g} >~ {1:g}, is False".format(a,le))
-            self.assertFalse(self.fn(a,gt),"{0:g} >~ {1:g}, is True".format(a,gt))
-            self.assertTrue(self.fn(a,lt),"{0:g} >~ {1:g}, is False".format(a,lt))
+        # This is floating due to floating point error
+        for a in [0.001, 1, 1.5, 4, 100, 1000]:
+            ge = a * (1 + 1e-5)
+            le = a * (1 - 1e-5)
+            gt = a * (1 + 1.1e-5)
+            lt = a * (1 - 1.1e-5)
+            self.assertTrue(self.fn(a, ge), "{0:g} >~ {1:g}, is False".format(a, ge))
+            self.assertTrue(self.fn(a, le), "{0:g} >~ {1:g}, is False".format(a, le))
+            self.assertFalse(self.fn(a, gt), "{0:g} >~ {1:g}, is True".format(a, gt))
+            self.assertTrue(self.fn(a, lt), "{0:g} >~ {1:g}, is False".format(a, lt))
 
     def testType(self):
         self.assertEqual(type(self.fn(1, 1)), bool)
@@ -528,12 +543,13 @@ class TestGreaterThanOrSimilarToEquation(unittest.TestCase):
     def tearDown(self):
         pass
 
+
 class TestLessThanEquation(unittest.TestCase):
     def setUp(self):
         self.fn = Expression("x < y")
-        
+
     def testRepr(self):
-        self.assertEqual(Expression(repr(self.fn)),self.fn)
+        self.assertEqual(Expression(repr(self.fn)), self.fn)
 
     def testCall(self):
         self.assertFalse(self.fn(1, 0))
@@ -551,12 +567,13 @@ class TestLessThanEquation(unittest.TestCase):
         self.assertEqual(type(self.fn(1, 1)), bool)
         self.assertFalse(self.fn(1, 1.0))
 
+
 class TestLessThanOrEqualToEquation(unittest.TestCase):
     def setUp(self):
         self.fn = Expression("x <= y")
-        
+
     def testRepr(self):
-        self.assertEqual(Expression(repr(self.fn)),self.fn)
+        self.assertEqual(Expression(repr(self.fn)), self.fn)
 
     def testCall(self):
         self.assertFalse(self.fn(1, 0))
@@ -583,22 +600,22 @@ class TestLessThanOrSimilarToEquation(unittest.TestCase):
         self.fn = Expression("x <~ y")
 
     def testRepr(self):
-        self.assertEqual(Expression(repr(self.fn)),self.fn)
+        self.assertEqual(Expression(repr(self.fn)), self.fn)
 
     def testCall(self):
         # Only use values close to 1
-        # floating point error may caluse failure for large expoents
+        # floating point error may cause failure for large exponents
         # i.e. for 10000 (1-(a(1-1e-5))/a)=1.0000000000065512e-05
-        # This is floating due to folating point error
-        for a in [0.001,1,1.5,4,100,1000]: 
-            ge = a*(1+1e-5)
-            le = a*(1-1e-5)
-            gt = a*(1+1.1e-5)
-            lt = a*(1-1.1e-5)
-            self.assertTrue(self.fn(a,ge),"{0:g} <~ {1:g}, is False".format(a,ge))
-            self.assertTrue(self.fn(a,le),"{0:g} <~ {1:g}, is False".format(a,le))
-            self.assertTrue(self.fn(a,gt),"{0:g} <~ {1:g}, is False".format(a,gt))
-            self.assertFalse(self.fn(a,lt),"{0:g} <~ {1:g}, is True".format(a,lt))
+        # This is floating due to floating point error
+        for a in [0.001, 1, 1.5, 4, 100, 1000]:
+            ge = a * (1 + 1e-5)
+            le = a * (1 - 1e-5)
+            gt = a * (1 + 1.1e-5)
+            lt = a * (1 - 1.1e-5)
+            self.assertTrue(self.fn(a, ge), "{0:g} <~ {1:g}, is False".format(a, ge))
+            self.assertTrue(self.fn(a, le), "{0:g} <~ {1:g}, is False".format(a, le))
+            self.assertTrue(self.fn(a, gt), "{0:g} <~ {1:g}, is False".format(a, gt))
+            self.assertFalse(self.fn(a, lt), "{0:g} <~ {1:g}, is True".format(a, lt))
 
     def testType(self):
         self.assertEqual(type(self.fn(1, 1)), bool)


### PR DESCRIPTION
These are spelling fixes and code style fixes.
Fixes failing tests from #22

The code style is PEP8 which is the de-facto python standard coding style.
http://legacy.python.org/dev/peps/pep-0008/

You can check pep8 by running

```
python setup.py flake8
```

Pay attention to lines with `# noqa`, these are ignored lines for the checks which may or may not be problematic.
