### PR TITLE
Test calling on empty equation, triggering error

### DIFF
--- a/tests/test_Equation.py
+++ b/tests/test_Equation.py
@@ -75,6 +75,9 @@ class TestEmpty(unittest.TestCase):
 
     def testStr(self):
         self.assertEqual(str(self.fn),"")
+        
+    def testCall(self):
+        self.assertEqual(self.fn(), 0)
 
     def tearDown(self):
         pass


### PR DESCRIPTION
Improve test case #25 guarding against another way of invoking the bug.

The test fails and it should as that call **still** raises an exception.
